### PR TITLE
Deep of Night Debuffs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elden-ring-nightreign-relic-browser",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Browse, search, and manage your Elden Ring Nightreign relics with our powerful save file browser. View all your collected relics, items, and effects across multiple character slots.",
   "keywords": [
     "elden-ring",

--- a/src/components/ComboFinder.tsx
+++ b/src/components/ComboFinder.tsx
@@ -21,7 +21,7 @@ import {
 } from "@mui/material";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { EffectKey, type Effect } from "../resources/effects";
+import { EffectKey, EffectType, type Effect } from "../resources/effects";
 import { items, ItemType } from "../resources/items";
 import type { CharacterSlot, SaveFileData } from "../types/SaveFile";
 import {
@@ -296,6 +296,12 @@ export function ComboFinder(props: ComboFinderProps) {
 
   const handleEffectChange = useCallback(
     (newEffect: Effect) => {
+      if (newEffect.type === EffectType.Debuff) {
+        setNotice(
+          "Sorry, debuffs are not supported yet. I'll add support for them soon!"
+        );
+        return;
+      }
       if (selectedEffects.length >= 9) {
         setNotice("You can't select more than 9 effects.");
         return;

--- a/src/components/RelicBrowser.tsx
+++ b/src/components/RelicBrowser.tsx
@@ -49,7 +49,11 @@ export function RelicBrowser({
         return false;
       }
       const itemName = getItemName(itemId);
-      const effectNames = effects.map(([effect]) => getEffectName(effect));
+      const effectNames = effects.flatMap(([effect, debuff]) =>
+        debuff !== undefined
+          ? [getEffectName(effect), getEffectName(debuff)]
+          : [getEffectName(effect)]
+      );
       const itemColor = getRelicColor(itemId);
 
       if (!doesRelicColorMatch(itemColor, selectedColor)) {

--- a/src/components/RelicBrowser.tsx
+++ b/src/components/RelicBrowser.tsx
@@ -49,7 +49,7 @@ export function RelicBrowser({
         return false;
       }
       const itemName = getItemName(itemId);
-      const effectNames = effects.map(getEffectName);
+      const effectNames = effects.map(([effect]) => getEffectName(effect));
       const itemColor = getRelicColor(itemId);
 
       if (!doesRelicColorMatch(itemColor, selectedColor)) {

--- a/src/components/RelicCard.tsx
+++ b/src/components/RelicCard.tsx
@@ -168,7 +168,7 @@ const RelicCardComponent: React.FC<RelicCardProps> = ({
         </Box>
 
         <List sx={{ listStyleType: "disc", pl: 2, py: 0 }}>
-          {effects.map((effect, index) => {
+          {effects.map(([effect], index) => {
             const effectName = getEffectName(effect);
             const effectHighlight = highlightSearchTerm(effectName, searchTerm);
             const highlightEffect =
@@ -269,8 +269,8 @@ export const RelicCard = React.memo(
     }
 
     // Check if any effect highlighting changed
-    for (const effectId of effects) {
-      const effectName = getEffectName(effectId);
+    for (const [effect] of effects) {
+      const effectName = getEffectName(effect);
       const prevEffectHighlight = highlightSearchTerm(
         effectName,
         prevProps.searchTerm

--- a/src/components/RelicCard.tsx
+++ b/src/components/RelicCard.tsx
@@ -168,7 +168,7 @@ const RelicCardComponent: React.FC<RelicCardProps> = ({
         </Box>
 
         <List sx={{ listStyleType: "disc", pl: 2, py: 0 }}>
-          {effects.map(([effect], index) => {
+          {effects.map(([effect, debuff], index) => {
             const effectName = getEffectName(effect);
             const effectHighlight = highlightSearchTerm(effectName, searchTerm);
             const highlightEffect =
@@ -176,6 +176,20 @@ const RelicCardComponent: React.FC<RelicCardProps> = ({
               highlightedEffects.some((highlighted) =>
                 isSameGroupAndEqualOrBetter(highlighted, effect)
               );
+
+            const debuffName =
+              debuff !== undefined ? getEffectName(debuff) : "";
+            const debuffHighlight =
+              debuff !== undefined
+                ? highlightSearchTerm(debuffName, searchTerm)
+                : undefined;
+            const highlightDebuff =
+              debuff !== undefined
+                ? highlightedEffects.includes(debuff) ||
+                  highlightedEffects.some((highlighted) =>
+                    isSameGroupAndEqualOrBetter(highlighted, debuff)
+                  )
+                : false;
 
             return (
               <Box key={index} sx={{ mb: 0.5, display: "list-item" }}>
@@ -191,6 +205,22 @@ const RelicCardComponent: React.FC<RelicCardProps> = ({
                   }}
                 >
                   {effectHighlight.highlightedText}
+
+                  {debuffHighlight && (
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        color:
+                          highlightedEffects.length === 0
+                            ? "#76adde"
+                            : highlightDebuff
+                              ? "primary.main"
+                              : "#76adde",
+                      }}
+                    >
+                      {debuffHighlight.highlightedText}
+                    </Typography>
+                  )}
                 </Typography>
               </Box>
             );

--- a/src/components/RelicCard.tsx
+++ b/src/components/RelicCard.tsx
@@ -299,7 +299,7 @@ export const RelicCard = React.memo(
     }
 
     // Check if any effect highlighting changed
-    for (const [effect] of effects) {
+    for (const [effect, debuff] of effects) {
       const effectName = getEffectName(effect);
       const prevEffectHighlight = highlightSearchTerm(
         effectName,
@@ -315,6 +315,25 @@ export const RelicCard = React.memo(
         nextEffectHighlight.hasMatch === true
       ) {
         return false;
+      }
+
+      if (debuff !== undefined) {
+        const debuffName = getEffectName(debuff);
+        const prevDebuffHighlight = highlightSearchTerm(
+          debuffName,
+          prevProps.searchTerm
+        );
+        const nextDebuffHighlight = highlightSearchTerm(
+          debuffName,
+          nextProps.searchTerm
+        );
+
+        if (
+          prevDebuffHighlight.hasMatch === true ||
+          nextDebuffHighlight.hasMatch === true
+        ) {
+          return false;
+        }
       }
     }
 

--- a/src/components/RelicDisplay.tsx
+++ b/src/components/RelicDisplay.tsx
@@ -122,8 +122,10 @@ export const RelicDisplay: React.FC<RelicDisplayProps> = ({
                   {rowRelics.flatMap((relic) => {
                     const { itemId, effects } = relic;
                     const itemName = getItemName(itemId);
-                    const effectNames = effects.map(([effect]) =>
-                      getEffectName(effect)
+                    const effectNames = effects.flatMap(([effect, debuff]) =>
+                      debuff !== undefined
+                        ? [getEffectName(effect), getEffectName(debuff)]
+                        : [getEffectName(effect)]
                     );
 
                     // Check if this relic matches the search

--- a/src/components/RelicDisplay.tsx
+++ b/src/components/RelicDisplay.tsx
@@ -122,7 +122,9 @@ export const RelicDisplay: React.FC<RelicDisplayProps> = ({
                   {rowRelics.flatMap((relic) => {
                     const { itemId, effects } = relic;
                     const itemName = getItemName(itemId);
-                    const effectNames = effects.map(getEffectName);
+                    const effectNames = effects.map(([effect]) =>
+                      getEffectName(effect)
+                    );
 
                     // Check if this relic matches the search
                     const relicMatches = doesRelicMatch(

--- a/src/components/RelicsPage.tsx
+++ b/src/components/RelicsPage.tsx
@@ -65,7 +65,9 @@ export function RelicsPage({
       return [];
     }
     const effects = currentSlot?.relics.flatMap((relic) =>
-      relic.effects.map(([effect]) => effect)
+      relic.effects.flatMap(([effect, debuff]) =>
+        debuff !== undefined ? [effect, debuff] : [effect]
+      )
     );
     const uniqueEffects = effects.filter(
       (effect, index, arr) =>

--- a/src/components/RelicsPage.tsx
+++ b/src/components/RelicsPage.tsx
@@ -64,7 +64,9 @@ export function RelicsPage({
     if (!currentSlot) {
       return [];
     }
-    const effects = currentSlot?.relics.flatMap((relic) => relic.effects);
+    const effects = currentSlot?.relics.flatMap((relic) =>
+      relic.effects.map(([effect]) => effect)
+    );
     const uniqueEffects = effects.filter(
       (effect, index, arr) =>
         arr.findIndex((e) => e.key === effect.key) === index

--- a/src/resources/effects.ts
+++ b/src/resources/effects.ts
@@ -56,7 +56,7 @@ export const enum EffectGroup {
   vigor,
 }
 
-const enum EffectType {
+export const enum EffectType {
   Debuff,
 }
 
@@ -4956,6 +4956,7 @@ export interface Effect {
   group?: EffectGroup;
   level?: number;
   startingBonus?: StartingBonus;
+  type?: EffectType;
 }
 
 export const effects: Map<number, Effect> = new Map();

--- a/src/test/SaveFile.test.ts
+++ b/src/test/SaveFile.test.ts
@@ -217,8 +217,8 @@ describe("Save File Processing", () => {
               expect(itemColor).toBeDefined();
               expect(itemColor).toBeTypeOf("number");
 
-              const effectNames = effects.map((effectId) =>
-                getEffectName(effectId)
+              const effectNames = effects.map(([effect]) =>
+                getEffectName(effect)
               );
               effectNames.forEach((effectName, index) => {
                 expect(

--- a/src/types/SaveFile.ts
+++ b/src/types/SaveFile.ts
@@ -17,7 +17,7 @@ export interface BND4Entry {
 export interface RelicSlot {
   id: number;
   itemId: number;
-  effects: Effect[];
+  effects: [effect: Effect, debuff?: Effect][];
   coordinates: [row: number, column: number];
   coordinatesByColor: [row: number, column: number];
   sortKey?: number;

--- a/src/types/SaveFile.ts
+++ b/src/types/SaveFile.ts
@@ -1,5 +1,7 @@
 import type { Effect } from "../resources/effects";
 
+export type EffectWithOptionalDebuff = [effect: Effect, debuff?: Effect];
+
 export interface BND4Entry {
   index: number;
   size: number;
@@ -17,7 +19,7 @@ export interface BND4Entry {
 export interface RelicSlot {
   id: number;
   itemId: number;
-  effects: [effect: Effect, debuff?: Effect][];
+  effects: EffectWithOptionalDebuff[];
   coordinates: [row: number, column: number];
   coordinatesByColor: [row: number, column: number];
   sortKey?: number;

--- a/src/utils/ComboSearch.test.ts
+++ b/src/utils/ComboSearch.test.ts
@@ -14,6 +14,18 @@ import { RelicSlotColor } from "./RelicColor.js";
 import { RelicParser } from "./RelicParser";
 import { SaveFileDecryptor } from "./SaveFileDecryptor";
 
+// helper to build minimal RelicSlot for tests
+let testRelicId = 100000;
+function makeRelic(itemId: number, effect: Effect): RelicSlot {
+  return {
+    id: testRelicId++,
+    itemId,
+    effects: [[effect]],
+    coordinates: [0, 0],
+    coordinatesByColor: [0, 0],
+  } as RelicSlot;
+}
+
 describe("ComboSearch", () => {
   describe("searchCombinations", () => {
     let relics: RelicSlot[];
@@ -110,7 +122,9 @@ describe("ComboSearch", () => {
 
       for (const combo of result.combinations[0].relic_indices) {
         assert(combo !== null);
-        expect(relics[combo].effects).toContain(selectedEffect);
+        expect(relics[combo].effects.some(([e]) => e === selectedEffect)).toBe(
+          true
+        );
       }
       expect(result.combinations[0].points).toBeGreaterThanOrEqual(
         1 + 0.9 + 0.9
@@ -141,7 +155,9 @@ describe("ComboSearch", () => {
 
       for (const combo of result.combinations[0].relic_indices) {
         assert(combo !== null);
-        expect(relics[combo].effects).toContain(higherLevelEffect);
+        expect(
+          relics[combo].effects.some(([e]) => e === higherLevelEffect)
+        ).toBe(true);
       }
       expect(result.combinations[0].points).toBeGreaterThanOrEqual(
         1 + 0.9 + 0.9
@@ -173,7 +189,7 @@ describe("ComboSearch", () => {
       let stacks = 0;
       for (const combo of result.combinations[0].relic_indices) {
         assert(combo !== null);
-        if (relics[combo].effects.includes(selectedEffect)) {
+        if (relics[combo].effects.some(([e]) => e === selectedEffect)) {
           stacks++;
         }
       }
@@ -184,9 +200,7 @@ describe("ComboSearch", () => {
       const selectedEffect = getEffectByKey(EffectKey.strengthPlus1);
       assert(selectedEffect !== undefined);
 
-      const relics = [
-        { itemId: 129, effects: [selectedEffect] },
-      ] as RelicSlot[];
+      const relics = [makeRelic(129, selectedEffect)];
 
       const input = buildWasmInput(
         Nightfarer.Wylder,
@@ -214,9 +228,9 @@ describe("ComboSearch", () => {
       assert(otherEffect !== undefined);
 
       const relics = [
-        { itemId: 129, effects: [otherEffect] },
-        { itemId: 129, effects: [selectedEffect] },
-      ] as RelicSlot[];
+        makeRelic(129, otherEffect),
+        makeRelic(129, selectedEffect),
+      ];
 
       const input = buildWasmInput(
         Nightfarer.Wylder,
@@ -244,10 +258,10 @@ describe("ComboSearch", () => {
       assert(otherEffect !== undefined);
 
       const relics = [
-        { itemId: 129, effects: [otherEffect] },
-        { itemId: 129, effects: [selectedEffect] },
-        { itemId: 129, effects: [otherEffect] },
-      ] as RelicSlot[];
+        makeRelic(129, otherEffect),
+        makeRelic(129, selectedEffect),
+        makeRelic(129, otherEffect),
+      ];
 
       const input = buildWasmInput(
         Nightfarer.Wylder,
@@ -279,8 +293,8 @@ describe("ComboSearch", () => {
       assert(overridingEffect !== undefined);
 
       const relics = [
-        { itemId: 120, effects: [selectedEffect] }, // yellow
-        { itemId: 102, effects: [overridingEffect] }, // red
+        makeRelic(120, selectedEffect), // yellow
+        makeRelic(102, overridingEffect), // red
       ] as RelicSlot[];
 
       const input = buildWasmInput(

--- a/src/utils/DataUtils.ts
+++ b/src/utils/DataUtils.ts
@@ -12,6 +12,7 @@ import type {
   CharacterSlot,
   CompactCharacterSlot,
   CompactRelicSlot,
+  EffectWithOptionalDebuff,
 } from "../types/SaveFile";
 import { RelicSlotColor, type RelicColor } from "./RelicColor";
 
@@ -108,7 +109,9 @@ export const getCompactCharacterSlot = (
       const [itemId, ...effectIds] = relic;
       const color = getRelicColor(itemId);
       const indexByColor = relicsByColor[color].indexOf(relic);
-      const effects = effectIds.map(getEffect);
+      const effects = effectIds.map(
+        (id) => [getEffect(id)] as EffectWithOptionalDebuff
+      );
       return {
         id: index,
         itemId,

--- a/src/utils/RelicParser.ts
+++ b/src/utils/RelicParser.ts
@@ -1,4 +1,8 @@
-import type { BND4Entry, RelicSlot } from "../types/SaveFile";
+import type {
+  BND4Entry,
+  EffectWithOptionalDebuff,
+  RelicSlot,
+} from "../types/SaveFile";
 import { getEffect, getRelicColor } from "./DataUtils";
 import { RelicSlotColor, type RelicColor } from "./RelicColor";
 
@@ -168,9 +172,12 @@ export class RelicParser {
                 .map((effectKey, index) => {
                   const debuffKey = debuffKeys[index];
                   if (debuffKey !== -1) {
-                    return [getEffect(effectKey), getEffect(debuffKey)];
+                    return [
+                      getEffect(effectKey),
+                      getEffect(debuffKey),
+                    ] as EffectWithOptionalDebuff;
                   }
-                  return [getEffect(effectKey)];
+                  return [getEffect(effectKey)] as EffectWithOptionalDebuff;
                 });
 
               const slotInfo: RelicSlot = {
@@ -178,7 +185,10 @@ export class RelicParser {
                 itemId,
                 effects,
                 idBytes,
-              } as RelicSlot;
+                // coordinates will be set later
+                coordinates: [0, 0],
+                coordinatesByColor: [0, 0],
+              };
               foundSlots.push(slotInfo);
             }
 

--- a/src/utils/RelicParser.ts
+++ b/src/utils/RelicParser.ts
@@ -150,19 +150,28 @@ export class RelicParser {
               const itemId = this.readIntLE(itemIdBytes);
 
               // Extract effect IDs
-              const effect1Bytes = slotData.slice(16, 20);
-              const effect2Bytes = slotData.slice(20, 24);
-              const effect3Bytes = slotData.slice(24, 28);
-              const effect4Bytes = slotData.slice(28, 32);
+              const effectKeys = [
+                slotData.slice(16, 20),
+                slotData.slice(20, 24),
+                slotData.slice(24, 28),
+                slotData.slice(28, 32),
+              ].map(this.readIntLE);
+              const debuffKeys = [
+                slotData.slice(56, 60),
+                slotData.slice(60, 64),
+                slotData.slice(64, 68),
+                slotData.slice(68, 72),
+              ].map(this.readIntLE);
 
-              const effects = [
-                this.readIntLE(effect1Bytes),
-                this.readIntLE(effect2Bytes),
-                this.readIntLE(effect3Bytes),
-                this.readIntLE(effect4Bytes),
-              ]
+              const effects = effectKeys
                 .filter((id) => id !== -1)
-                .map(getEffect);
+                .map((effectKey, index) => {
+                  const debuffKey = debuffKeys[index];
+                  if (debuffKey !== -1) {
+                    return [getEffect(effectKey), getEffect(debuffKey)];
+                  }
+                  return [getEffect(effectKey)];
+                });
 
               const slotInfo: RelicSlot = {
                 id,

--- a/src/utils/RelicProcessor.test.ts
+++ b/src/utils/RelicProcessor.test.ts
@@ -9,14 +9,14 @@ describe("Relic Processor Functions", () => {
     it("should return a better relic", () => {
       const relic: RelicSlot = {
         id: 1,
-        effects: [getEffect(7000201)],
+        effects: [[getEffect(7000201)]],
         itemId: 104,
         coordinates: [0, 0],
         coordinatesByColor: [0, 0],
       };
       const betterRelic: RelicSlot = {
         id: 2,
-        effects: [getEffect(7000202)],
+        effects: [[getEffect(7000202)]],
         itemId: 107,
         coordinates: [0, 0],
         coordinatesByColor: [0, 0],
@@ -29,21 +29,21 @@ describe("Relic Processor Functions", () => {
     it("should return an equal relic", () => {
       const relic: RelicSlot = {
         id: 1,
-        effects: [getEffect(7000201)],
+        effects: [[getEffect(7000201)]],
         itemId: 104,
         coordinates: [0, 0],
         coordinatesByColor: [0, 0],
       };
       const betterRelic: RelicSlot = {
         id: 2,
-        effects: [getEffect(7000202)],
+        effects: [[getEffect(7000202)]],
         itemId: 107,
         coordinates: [0, 0],
         coordinatesByColor: [0, 0],
       };
       const equalRelic: RelicSlot = {
         id: 4,
-        effects: [getEffect(7000201)],
+        effects: [[getEffect(7000201)]],
         itemId: 107,
         coordinates: [0, 0],
         coordinatesByColor: [0, 0],
@@ -60,14 +60,14 @@ describe("Relic Processor Functions", () => {
     it("should not return any relic if colors are different", () => {
       const relic: RelicSlot = {
         id: 1,
-        effects: [getEffect(7000201)],
+        effects: [[getEffect(7000201)]],
         itemId: 104,
         coordinates: [0, 0],
         coordinatesByColor: [0, 0],
       };
       const betterRelicWithDifferentColor: RelicSlot = {
         id: 3,
-        effects: [getEffect(7000202)],
+        effects: [[getEffect(7000202)]],
         itemId: 1005100,
         coordinates: [0, 0],
         coordinatesByColor: [0, 0],

--- a/src/utils/RelicProcessor.ts
+++ b/src/utils/RelicProcessor.ts
@@ -24,7 +24,7 @@ export function findBetterRelic(
   relic: RelicSlot,
   relics: RelicSlot[]
 ): RelicSlot["redundant"] {
-  const effects = relic.effects;
+  const effects = relic.effects.map(([effect]) => effect);
   const relicsWithEnoughEffects = relics.filter(
     (r) => r.effects.length >= effects.length
   );
@@ -32,14 +32,15 @@ export function findBetterRelic(
     if (relic === r) {
       return false;
     }
+    const otherEffects = r.effects.map(([effect]) => effect);
     const isRedundant = effects.every((effect) => {
       const effectGroup = getEffectGroup(effect);
-      if (!effectGroup && r.effects.includes(effect)) {
+      if (!effectGroup && otherEffects.includes(effect)) {
         // The effect is present in both relics.
         return true;
       }
       if (effectGroup) {
-        const otherEffectGroups = r.effects.map((e) => getEffectGroup(e));
+        const otherEffectGroups = otherEffects.map(getEffectGroup);
         const otherEffectGroup = otherEffectGroups.find(
           (g) => g && g.group === effectGroup.group
         );
@@ -68,8 +69,8 @@ export function findBetterRelic(
       for (const effect of effects) {
         const effectGroup = getEffectGroup(effect);
         if (effectGroup) {
-          const otherEffectGroups = betterOrEqualRelic.effects.map((e) =>
-            getEffectGroup(e)
+          const otherEffectGroups = betterOrEqualRelic.effects.map(([effect]) =>
+            getEffectGroup(effect)
           );
           const otherEffectGroup = otherEffectGroups.find(
             (g) => g && g.group === effectGroup.group

--- a/src/workers/comboSearchWorker.ts
+++ b/src/workers/comboSearchWorker.ts
@@ -111,7 +111,7 @@ export function buildWasmInput(
     selected_effects: expandedSelectedEffects,
     relics: relics.map((r) => ({
       color: getRelicColor(r.itemId),
-      effects: r.effects,
+      effects: r.effects.map(([effect]) => effect),
     })),
     enabled_vessels: enabledVessels.map(({ slots }) => slots),
     recommended_effects: filteredRecommendedEffects,


### PR DESCRIPTION
Enables viewing and searching debuffs in the Relic Browser. The Combo Finder still does not support Deep Relics. This will be done in a future update.